### PR TITLE
docs: Provide example commands for developing with replaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ in the latest Decred release.
 Alternatively, a development build can be performed by running `go install` in a
 locally checked-out repository.
 
+## Developing
+
+When developing either the dcrd or dcrwallet RPC servers and making
+modifications to the RPC methods, you may want to build a development version of
+dcrctl supporting these changes.  Due to dcrctl being built around
+package-global method registrations and reflection, supporting these changes
+only requires building with the updated packages.  To perform this, module
+replacements may be utilized to point to development versions of dcrd and
+dcrwallet in your build environment:
+
+```
+$ go mod edit -replace=github.com/decred/dcrd/rpc/jsonrpc/types/v2=../dcrd/rpc/jsonrpc/types
+$ go mod edit -replace=decred.org/dcrwallet=../dcrwallet
+```
+
+These replaces should be removed prior to committing any updated module
+requires:
+
+```
+$ go mod edit -dropreplace=github.com/decred/dcrd/rpc/jsonrpc/types/v2
+$ go mod edit -dropreplace=decred.org/dcrwallet
+```
+
 ## Contact
 
 If you have any further questions you can find us at:


### PR DESCRIPTION
The major versions of the modules in these examples must be updated as
dcrctl imports new major versions of the packages in the future.