### PR TITLE
Add ClientCert and ClientKey for newly required grpc auth

### DIFF
--- a/config.go
+++ b/config.go
@@ -128,6 +128,7 @@ type config struct {
 	TLSSkipVerify   bool   `long:"skipverify" description:"Do not verify tls certificates (not recommended!)"`
 	Wallet          bool   `long:"wallet" description:"Connect to wallet"`
 
+	WalletGRPC bool   `long:"walletgrpc" description:"This flag is required if the wallet that is being connected to requires client certs for grpc."`
 	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
 	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
 }
@@ -341,6 +342,18 @@ func loadConfig() (*config, []string, error) {
 		cfg.RPCCert = defaultWalletCertFile
 	}
 
+	if cfg.Wallet && cfg.WalletGRPC {
+		// Set path for the client key/cert depending on if they are set in options
+		if cfg.ClientCert == "" {
+			cfg.ClientCert = defaultClientCertFile
+		}
+		if cfg.ClientKey == "" {
+			cfg.ClientKey = defaultClientKeyFile
+		}
+
+		cfg.ClientCert = cleanAndExpandPath(cfg.ClientCert)
+		cfg.ClientKey = cleanAndExpandPath(cfg.ClientKey)
+	}
 	// When the --wallet flag is specified, use the walletrpcserver port
 	// if specified.
 	if cfg.Wallet && cfg.WalletRPCServer != defaultWalletRPCServer {

--- a/config.go
+++ b/config.go
@@ -128,9 +128,9 @@ type config struct {
 	TLSSkipVerify   bool   `long:"skipverify" description:"Do not verify tls certificates (not recommended!)"`
 	Wallet          bool   `long:"wallet" description:"Connect to wallet"`
 
-	WalletGRPC bool   `long:"walletgrpc" description:"This flag is required if the wallet that is being connected to requires client certs for grpc."`
-	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
-	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
+	AuthType   string `long:"authtype" description:"Which authtype the connected wallet is currently using. (cannot be used with notls)"`
+	ClientCert string `long:"clientcert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"clientkey" description:"Path to TLS client authentication key"`
 }
 
 // normalizeAddress returns addr with the passed default port appended if
@@ -342,7 +342,10 @@ func loadConfig() (*config, []string, error) {
 		cfg.RPCCert = defaultWalletCertFile
 	}
 
-	if cfg.Wallet && cfg.WalletGRPC {
+	if cfg.Wallet && cfg.AuthType == "clientcert" {
+		if cfg.NoTLS {
+			return nil, nil, fmt.Errorf("cannot use notls and clientcert authtype at the same time")
+		}
 		// Set path for the client key/cert depending on if they are set in options
 		if cfg.ClientCert == "" {
 			cfg.ClientCert = defaultClientCertFile

--- a/config.go
+++ b/config.go
@@ -30,6 +30,8 @@ const (
 	// able to use.  In particular it doesn't support websockets and
 	// consequently notifications.
 	unusableFlags = dcrjson.UFWebsocketOnly | dcrjson.UFNotification
+
+	clientCertFile = "client.pem"
 )
 
 var (
@@ -37,6 +39,8 @@ var (
 	dcrctlHomeDir          = dcrutil.AppDataDir("dcrctl", false)
 	dcrwalletHomeDir       = dcrutil.AppDataDir("dcrwallet", false)
 	defaultConfigFile      = filepath.Join(dcrctlHomeDir, "dcrctl.conf")
+	defaultClientCertFile  = filepath.Join(dcrctlHomeDir, "client.pem")
+	defaultClientKeyFile   = filepath.Join(dcrctlHomeDir, "client-key.pem")
 	defaultRPCServer       = "localhost"
 	defaultWalletRPCServer = "localhost"
 	defaultRPCCertFile     = filepath.Join(dcrdHomeDir, "rpc.cert")
@@ -123,6 +127,9 @@ type config struct {
 	SimNet          bool   `long:"simnet" description:"Connect to the simulation test network"`
 	TLSSkipVerify   bool   `long:"skipverify" description:"Do not verify tls certificates (not recommended!)"`
 	Wallet          bool   `long:"wallet" description:"Connect to wallet"`
+
+	ClientCert string `long:"cert" description:"Path to TLS certificate for client authentication"`
+	ClientKey  string `long:"key" description:"Path to TLS client authentication key"`
 }
 
 // normalizeAddress returns addr with the passed default port appended if

--- a/config.go
+++ b/config.go
@@ -30,8 +30,6 @@ const (
 	// able to use.  In particular it doesn't support websockets and
 	// consequently notifications.
 	unusableFlags = dcrjson.UFWebsocketOnly | dcrjson.UFNotification
-
-	clientCertFile = "client.pem"
 )
 
 var (

--- a/httpclient.go
+++ b/httpclient.go
@@ -45,7 +45,7 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 		tlsConfig = &tls.Config{
 			InsecureSkipVerify: cfg.TLSSkipVerify,
 		}
-		if !cfg.TLSSkipVerify && cfg.Wallet && cfg.ClientCert != "" {
+		if !cfg.TLSSkipVerify && cfg.WalletGRPC {
 			serverCAs := x509.NewCertPool()
 			serverCert, err := ioutil.ReadFile(cfg.RPCCert)
 			if err != nil {

--- a/httpclient.go
+++ b/httpclient.go
@@ -45,7 +45,7 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 		tlsConfig = &tls.Config{
 			InsecureSkipVerify: cfg.TLSSkipVerify,
 		}
-		if !cfg.TLSSkipVerify && cfg.WalletGRPC {
+		if !cfg.TLSSkipVerify && cfg.AuthType == "clientcert" {
 			serverCAs := x509.NewCertPool()
 			serverCert, err := ioutil.ReadFile(cfg.RPCCert)
 			if err != nil {

--- a/httpclient.go
+++ b/httpclient.go
@@ -63,7 +63,8 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 			tlsConfig.Certificates = []tls.Certificate{keypair}
 			tlsConfig.RootCAs = serverCAs
 
-		} else if !cfg.TLSSkipVerify && cfg.RPCCert != "" {
+		}
+		if !cfg.TLSSkipVerify && cfg.RPCCert != "" {
 			pem, err := ioutil.ReadFile(cfg.RPCCert)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Requires https://github.com/decred/dcrwallet/pull/1867

This diff adds 3 new options to be able to use dcrctl against a wallet that has `authtype=clientcert`

`WalletGRPC` should be set to true in this case and then it will pull the required cert and key from 
the default location (~/.dcrctl/client.pem and ~/.dcrctl/client-key.pem) or use whatever path the user
sets for `ClientCert` and `ClientKey`.  The client.pem needs to also be appended to the dcrwallet
clients.pem file.