### PR TITLE
Cleanup authtype option.

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -45,7 +45,7 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 		tlsConfig = &tls.Config{
 			InsecureSkipVerify: cfg.TLSSkipVerify,
 		}
-		if !cfg.TLSSkipVerify && cfg.AuthType == "clientcert" {
+		if !cfg.TLSSkipVerify && cfg.AuthType == authTypeClientCert {
 			serverCAs := x509.NewCertPool()
 			serverCert, err := ioutil.ReadFile(cfg.RPCCert)
 			if err != nil {


### PR DESCRIPTION
This modifies the config parsing for the new `authtype` option to enforce only the two supported types and sets the default to the `userpass` type.

It also enforces that the new `authtype` of `clientcert` requires TLS regardless of the `wallet` flag being set because it is perfectly
acceptable to manually specify a wallet as a target without the wallet flag that tells it to use the default ports.

Finally, it modifies it so that the client cert and key are loaded when the authorization type is `clientcert` regardless of the `wallet` flag for the same reason as above.