### PR TITLE
[release-v1.7] release: Bump for 1.7.0.

### DIFF
--- a/version.go
+++ b/version.go
@@ -35,14 +35,14 @@ var (
 	// '-ldflags "-X main.PreRelease=foo"'
 	// if needed.  It MUST only contain characters from semanticAlphabet per
 	// the semantic versioning spec.
-	PreRelease = "pre"
+	PreRelease = ""
 
 	// BuildMetadata is defined as a variable so it can be overridden during the
 	// build process with:
 	// '-ldflags "-X main.BuildMetadata=foo"'
 	// if needed.  It MUST only contain characters from semanticBuildAlphabet
 	// per the semantic versioning spec.
-	BuildMetadata = ""
+	BuildMetadata = "release.local"
 )
 
 // versionString returns the application version as a properly formed string per


### PR DESCRIPTION
This clears the `PreRelease` and sets the `BuildMetadata` to `release.local` on the release branch so that anyone building the release branch will end up with version "1.7.0+release.local" indicating it was a local build as opposed to a reproducible release build.