### PR TITLE
[release-v1.7] deps: Update modules for v1.7.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module decred.org/dcrctl
 go 1.16
 
 require (
-	decred.org/dcrwallet/v2 v2.0.0-rc1
+	decred.org/dcrwallet/v2 v2.0.0
 	github.com/decred/dcrd/dcrjson/v4 v4.0.0
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrwallet/v2 v2.0.0-rc1 h1:lJuI3srFWmy5SNB5X4e2X9xJZXXJ6hMbI3bsXEqBfPQ=
-decred.org/dcrwallet/v2 v2.0.0-rc1/go.mod h1:IOIVwOFCpA1Xhqz4Xo26IaD5qZN01EZRGyCJOZYnoc4=
+decred.org/cspp/v2 v2.0.0/go.mod h1:0shJWKTWY3LxZEWGxtbER1Y45+HVjC0WZtj4bctSzCI=
+decred.org/dcrwallet/v2 v2.0.0 h1:nOGChwR5RM4QLmbm/Krit6/eQryv/RvcpUxxmUThfKI=
+decred.org/dcrwallet/v2 v2.0.0/go.mod h1:lZXgx5OcLDaWyNWFkBekqER1gdqiVwua1w68SFC1/Nk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=


### PR DESCRIPTION
This is a backport of #40 to the 1.7 release branch.