### PR TITLE
multi: Update for Go 1.18.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,11 +9,11 @@ jobs:
         go: [1.16, 1.17]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@v2
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3.0.0
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: [1.17, 1.18]
     steps:
       - name: Set up Go
         uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrctl
 
-go 1.16
+go 1.17
 
 require (
 	decred.org/dcrwallet/v2 v2.0.0
@@ -9,4 +9,20 @@ require (
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0
 	github.com/decred/go-socks v1.1.0
 	github.com/jessevdk/go-flags v1.4.1-0.20200711081900-c17162fe8fd7
+)
+
+require (
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/dchest/siphash v1.2.2 // indirect
+	github.com/decred/base58 v1.0.3 // indirect
+	github.com/decred/dcrd/chaincfg/chainhash v1.0.3 // indirect
+	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+	github.com/decred/dcrd/crypto/ripemd160 v1.0.1 // indirect
+	github.com/decred/dcrd/dcrec v1.0.0 // indirect
+	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2 // indirect
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/decred/dcrd/txscript/v4 v4.0.0 // indirect
+	github.com/decred/dcrd/wire v1.5.0 // indirect
+	github.com/decred/slog v1.2.0 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
 )


### PR DESCRIPTION
This contains several updates to bump to fully support Go 1.18 and use the latest versions of various tooling.  In particular:

- Test against Go 1.18.
- Update main module to support Go 1.17 semantics.
- Update to latest action versions:
  - actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0
  - actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3.0.0
  - Uses the pinned hash to help prevent supply chain attacks
- Use recommended golangci-lint installer and update to the latest version 1.45.2.