### PR TITLE
multi: Build and doco updates for Go 1.19.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - name: Install linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,12 +1,15 @@
 name: Build and Test
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Go CI
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.17, 1.18]
+        go: [1.18, 1.19]
     steps:
       - name: Set up Go
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
@@ -17,14 +20,8 @@ jobs:
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0"
       - name: Build
-        env:
-          GO111MODULE: "on"
         run: go build ./...
       - name: Lint
-        env:
-          GO111MODULE: "on"
         run: golangci-lint run --disable-all --deadline=10m --enable=gofmt --enable=govet --enable=gosimple --enable=unconvert --enable=ineffassign
       - name: Test
-        env:
-          GO111MODULE: "on"
         run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,11 +9,11 @@ jobs:
         go: [1.17, 1.18]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@f6164bd8c8acb4a71fb2791a8b6c4024ff038dab #v3.0.0
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 #v3.0.0
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2"
       - name: Build

--- a/README.md
+++ b/README.md
@@ -28,19 +28,36 @@ changes may be written to a config file in a platform-specific location:
 
 ## Build and installation
 
-The latest dcrctl may be built in a single command without cloning this
-repository:
+- **Install Go 1.18 or 1.19**
 
-```
-$ GO111MODULE=on go get decred.org/dcrctl
-```
+  Installation instructions can be found here: https://golang.org/doc/install.
+  Ensure Go was installed properly and is a supported version:
+  ```sh
+  $ go version
+  $ go env GOROOT GOPATH
+  ```
+  NOTE: `GOROOT` and `GOPATH` must not be on the same path. It is recommended
+  to add `$GOPATH/bin` to your `PATH` according to the Golang.org instructions.
 
-Appending `@master` to this will perform a release build using the latest code
-from the master branch.  This may be useful to execute RPC methods not yet found
-in the latest Decred release.
+- **Build or Update dcrctl**
 
-Alternatively, a development build can be performed by running `go install` in a
-locally checked-out repository.
+  The latest release of dcrctl may be built in a single command without cloning
+  this repository:
+
+  ```sh
+  $ go install decred.org/dcrctl@release-v1.7.4
+  ```
+
+  Using `@master` instead will perform a release build using the latest code
+  from the master branch.  This may be useful to execute RPC methods not yet
+  found in the latest Decred release:
+
+  ```sh
+  $ go install decred.org/dcrctl@master
+  ```
+
+  Alternatively, a development build can be performed by running `go install` in
+  a locally checked-out repository.
 
 ## Developing
 

--- a/config.go
+++ b/config.go
@@ -238,10 +238,10 @@ func fileExists(name string) bool {
 // line options.
 //
 // The configuration proceeds as follows:
-// 	1) Start with a default config with sane settings
-// 	2) Pre-parse the command line to check for an alternative config file
-// 	3) Load configuration file overwriting defaults with any specified options
-// 	4) Parse CLI options and overwrite/add any specified options
+//  1. Start with a default config with sane settings
+//  2. Pre-parse the command line to check for an alternative config file
+//  3. Load configuration file overwriting defaults with any specified options
+//  4. Parse CLI options and overwrite/add any specified options
 //
 // The above results in functioning properly without any config settings
 // while still allowing the user to override settings with config files and


### PR DESCRIPTION
This consists of several commit to update the CI and documentation for Go 1.19.  It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- main: Go 1.19 doc comment formatting.
- build: Update to latest action versions.
  - `actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1`
  - `actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2`
- build: Update golangci-lint to v1.48.0.
- build: Test against Go 1.19 and remove Go 1.17 accordingly.
- docs: Update README.md for Go 1.19 and rel 1.7.4.
