### PR TITLE
multi: Don't use deprecated ioutil package.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,7 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"os/user"
@@ -408,7 +408,7 @@ func createDefaultConfigFile(destinationPath string) error {
 		return err
 	}
 	defer dcrdConfigFile.Close()
-	content, err := ioutil.ReadAll(dcrdConfigFile)
+	content, err := io.ReadAll(dcrdConfigFile)
 	if err != nil {
 		return err
 	}

--- a/httpclient.go
+++ b/httpclient.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2020 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,9 +11,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
+	"os"
 
 	"github.com/decred/dcrd/dcrjson/v4"
 	"github.com/decred/go-socks/socks"
@@ -47,7 +48,7 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 		}
 		if !cfg.TLSSkipVerify && cfg.AuthType == authTypeClientCert {
 			serverCAs := x509.NewCertPool()
-			serverCert, err := ioutil.ReadFile(cfg.RPCCert)
+			serverCert, err := os.ReadFile(cfg.RPCCert)
 			if err != nil {
 				return nil, err
 			}
@@ -65,7 +66,7 @@ func newHTTPClient(cfg *config) (*http.Client, error) {
 
 		}
 		if !cfg.TLSSkipVerify && cfg.RPCCert != "" {
-			pem, err := ioutil.ReadFile(cfg.RPCCert)
+			pem, err := os.ReadFile(cfg.RPCCert)
 			if err != nil {
 				return nil, err
 			}
@@ -129,7 +130,7 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) ([]byte, error) {
 	}
 
 	// Read the raw bytes and close the response.
-	respBytes, err := ioutil.ReadAll(httpResponse.Body)
+	respBytes, err := io.ReadAll(httpResponse.Body)
 	httpResponse.Body.Close()
 	if err != nil {
 		err = fmt.Errorf("error reading json reply: %w", err)


### PR DESCRIPTION
As of go 1.16, the "io/ioutil" package is deprecated. All functionality from "io/ioutil" has been moved to either the "io" or "os" packages.