### PR TITLE
multi: Build and doco updates for Go 1.20.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.18, 1.19]
+        go: ["1.19", "1.20"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
       - name: Install linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
       - name: Build
         run: go build ./...
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,11 @@ jobs:
         go: [1.18, 1.19]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a #v3.2.1
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v3.0.2
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.48.0"
       - name: Build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ changes may be written to a config file in a platform-specific location:
 
 ## Build and installation
 
-- **Install Go 1.18 or 1.19**
+- **Install Go 1.19 or 1.20**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.20. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
  - actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
- build: Update golangci-lint to v1.51.1.
- build: Test against Go 1.20 and remove Go 1.18 accordingly.
- docs: Update README.md to required Go 1.19/1.20.
