### PR TITLE
[release-v1.8] release: Bump for 1.8.0.

### DIFF
--- a/version.go
+++ b/version.go
@@ -53,7 +53,7 @@ var (
 	// the app will panic at runtime.  Of particular note is the pre-release
 	// and build metadata portions MUST only contain characters from
 	// semanticAlphabet.
-	Version = "1.8.0-pre"
+	Version = "1.8.0+release.local"
 
 	// NOTE: The following values are set via init by parsing the above Version
 	// string.


### PR DESCRIPTION
This clears the PreRelease and sets the BuildMetadata to release.local on the release branch so that anyone building the release branch will end up with version "1.8.0+release.local" indicating it was a local build as opposed to a reproducible release build.