### PR TITLE
docs: Extend go install tutorial.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ changes may be written to a config file in a platform-specific location:
 
 ## Build and installation
 
-- **Install Go 1.19 or 1.20**
+- **Install Go 1.19 or higher version**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:
@@ -36,7 +36,9 @@ changes may be written to a config file in a platform-specific location:
   $ go version
   $ go env GOROOT GOPATH
   ```
-  NOTE: `GOROOT` and `GOPATH` must not be on the same path (if these are initialized).
+  NOTE: if `GOROOT` and `GOPATH` are initialized they must not be on the same path.
+  It is recommended to add `$GOPATH/bin` to your `PATH` according to the Golang.org
+  instructions.
 
 - **Build or Update dcrctl**
 
@@ -58,11 +60,13 @@ changes may be written to a config file in a platform-specific location:
   Alternatively, a development build can be performed by running `go install` in
   a locally checked-out repository.
 
-  If you want to easily access dcrctl via `dcrctl` handle on command-line, since
-  `go install` will put **dcrctl** binary in `go env GOPATH` you might need to
-  ensure the `go env GOPATH` dir (or just **dcrctl** binary) is present in your
-  `$PATH` (on Linux you might want to update your
-  [~/.bashrc](https://stackoverflow.com/a/21012349) to achieve that).
+  If you want to easily access `dcrctl` from the command-line without having to
+  type the full path to the binary every time, ensure the bin directory rooted
+  at the path reported by `go env GOPATH` is added to your system path:
+
+  * macOS: [how to add binary to your PATH](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7#mac-os-x)
+  * Windows: [how to add binary to your PATH](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7#windows)
+  * Linux and other Unix: [how to add binary to your PATH](https://gist.github.com/nex3/c395b2f8fd4b02068be37c961301caa7#linux)
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ changes may be written to a config file in a platform-specific location:
   $ go version
   $ go env GOROOT GOPATH
   ```
-  NOTE: `GOROOT` and `GOPATH` must not be on the same path. It is recommended
-  to add `$GOPATH/bin` to your `PATH` according to the Golang.org instructions.
+  NOTE: `GOROOT` and `GOPATH` must not be on the same path (if these are initialized).
 
 - **Build or Update dcrctl**
 
@@ -58,6 +57,12 @@ changes may be written to a config file in a platform-specific location:
 
   Alternatively, a development build can be performed by running `go install` in
   a locally checked-out repository.
+
+  If you want to easily access dcrctl via `dcrctl` handle on command-line, since
+  `go install` will put **dcrctl** binary in `go env GOPATH` you might need to
+  ensure the `go env GOPATH` dir (or just **dcrctl** binary) is present in your
+  `$PATH` (on Linux you might want to update your
+  [~/.bashrc](https://stackoverflow.com/a/21012349) to achieve that).
 
 ## Developing
 


### PR DESCRIPTION
A suggestion to expand installation docs a bit (based on my recent experience of doing so on Linux).

Rendered version: https://github.com/norwnd/dcrctl/tree/docs-extend-go-install-tutorial