### PR TITLE
multi: Build and doco updates for Go 1.21.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.20", "1.21"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #4.1.0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Install linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2"
       - name: Build
         run: go build ./...
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,11 @@ jobs:
         go: ["1.19", "1.20"]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 #v3.5.0
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe #4.1.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.1"
       - name: Build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ changes may be written to a config file in a platform-specific location:
 
 ## Build and installation
 
-- **Install Go 1.19 or higher version**
+- **Install Go 1.20 or higher version**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.21. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # 4.1.0
  - actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
- build: Update golangci-lint to v1.54.2
- build: Test against Go 1.21 and remove Go 1.19 accordingly
- docs: Update README.md to required Go 1.20+
