### PR TITLE
multi: Build and doco updates for Go 1.24.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Install linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5"
       - name: Build
         run: go build ./...
       - name: Lint

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,11 +12,11 @@ jobs:
         go: ["1.22", "1.23"]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 #5.0.2
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #5.3.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Install linters
         run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.61.0"
       - name: Build

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.23", "1.24"]
     steps:
       - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #5.3.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - bodyclose
     - durationcheck
     - errchkjson
-    - exportloopref
     - gofmt
     - goimports
     - gosimple
@@ -24,3 +23,4 @@ linters:
     - typecheck
     - unconvert
     - unused
+    - usetesting

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ changes may be written to a config file in a platform-specific location:
 
 ## Build and installation
 
-- **Install Go 1.21 or higher version**
+- **Install Go 1.23 or higher version**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:


### PR DESCRIPTION
This consists of several commits to update the CI and documentation for Go 1.24. It also takes the opportunity to bump to the latest linter and action versions.

In particular:

- build: Update to latest action versions.
  - actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #5.3.0
  - actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
- build: Update golangci-lint to v1.64.5
- build: Test against Go 1.24 and remove Go 1.12 accordingly
- docs: Update README.md to required Go 1.23+
